### PR TITLE
Added ability to make multiple changes to the same guid or cls

### DIFF
--- a/PPDefModifier/PPDefModifier.cs
+++ b/PPDefModifier/PPDefModifier.cs
@@ -106,31 +106,7 @@ namespace PPDefModifier
                 foreach (var mod in mods)
                 {
                     ValidateModifier(mod);
-                    if (mod.field != null)
-                    {
-                        ApplyModifier(mod);
-                    }
-                    else
-                    {
-                        // Make a new ModifierDefinition for each modlet in the modlet list and apply it.
-                        foreach ( var modlet in mod.modletlist)
-                        {
-                            if (modlet.field == null || modlet.value == null)
-                            {
-                                // Skip any modlets that are malformed. Do this gracefully so we don't break a sequence.
-                                Debug.LogFormat("PPDefModifer: Modlet patch for {0} was missing a field or a class!", mod.guid ?? mod.cls);
-                                continue;
-                            }
-                            Debug.LogFormat("PPDefModifier: Applying modlet patch to {0}.{1}", mod.guid ?? mod.cls, modlet.field);
-                            ApplyModifier(new ModifierDefinition
-                            {
-                                guid = mod.guid,
-                                cls = mod.cls,
-                                field = modlet.field,
-                                value = modlet.value
-                            });
-                        }
-                    }
+                    ApplyModifier(mod);
                 }
             }
             catch (Exception e)
@@ -170,6 +146,33 @@ namespace PPDefModifier
             System.Object parent = null;
             int parentArrayIndex = -1;
             Type type = null;
+
+            // If modletlist are present then skip to generating new single modifiers, so that these tests
+            // don't get run one more time than needed
+            if (mod.modletlist != null)
+            {
+                // Make a new ModifierDefinition for each modlet in the modlet list and apply it.
+                foreach (ModletStep modlet in mod.modletlist)
+                {
+                    if (modlet.field == null || modlet.value == null)
+                    {
+                        // Skip any modlets that are malformed. Do this gracefully so we don't break a sequence.
+                        //Debug.LogFormat("PPDefModifer: Modlet patch for {0} was missing a field or a class!", mod.guid ?? mod.cls);
+                        continue;
+                    }
+                    //Debug.LogFormat("PPDefModifier: Applying modlet patch to {0}.{1}", mod.guid ?? mod.cls, modlet.field);
+                    ApplyModifier(new ModifierDefinition
+                    {
+                        guid = mod.guid,
+                        cls = mod.cls,
+                        field = modlet.field,
+                        value = modlet.value
+                    });
+                }
+
+                // Once we're done exit from the function.
+                return;
+            }
 
             // Try to find the def if we have a guid
             if (mod.guid != null)

--- a/PPDefModifier/Properties/AssemblyInfo.cs
+++ b/PPDefModifier/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.3.1.0")]
+[assembly: AssemblyFileVersion("1.3.1.0")]
 
 [assembly: InternalsVisibleTo("PPDefModifierTests")]

--- a/PPDefModifier/Properties/AssemblyInfo.cs
+++ b/PPDefModifier/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.1.0")]
-[assembly: AssemblyFileVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.4.1.0")]
+[assembly: AssemblyFileVersion("1.4.1.0")]
 
 [assembly: InternalsVisibleTo("PPDefModifierTests")]

--- a/PPDefModifierTests/ApplyModTests.cs
+++ b/PPDefModifierTests/ApplyModTests.cs
@@ -394,6 +394,46 @@ namespace PPDefModifierTests
             Assert.AreEqual(10, obj.nestedList[1].Value);
         }
 
+        [TestMethod]
+        public void TestModletList()
+        {
+            MockRepo repo = new MockRepo();
+            TestClass obj = new TestClass { intValue = 10, boolValue = false };
+            repo.AddDef("a", obj);
+            ModFile m = new ModFile("ModletList", repo);
+            ModifierDefinition mod = new ModifierDefinition { guid = "a", modletlist = new List<ModletStep> {
+                new ModletStep { field = "intValue", value = 20 },
+                new ModletStep { field = "boolValue", value = false}
+            }
+            };
+            m.ApplyModifier(mod);
+            Assert.AreEqual(obj.intValue, 20);
+            Assert.IsTrue(obj.boolValue);
+        }
+
+        [TestMethod]
+        public void TestModletListWithMalformedSteps()
+        {
+            MockRepo repo = new MockRepo();
+            TestClass obj = new TestClass { intValue = 10, boolValue = false };
+            repo.AddDef("a", obj);
+            ModFile m = new ModFile("ModletList", repo);
+            ModifierDefinition mod = new ModifierDefinition
+            {
+                guid = "a",
+                modletlist = new List<ModletStep> {
+                new ModletStep { field = "intValue", value = 20 },
+                new ModletStep { field = null, value = 20 },
+                new ModletStep { field = "NoValue", value = null },
+                new ModletStep { field = null, value = null },
+                new ModletStep { field = "boolValue", value = false}
+            }
+            };
+            m.ApplyModifier(mod);
+            Assert.AreEqual(obj.intValue, 20);
+            Assert.IsTrue(obj.boolValue);
+        }
+
     }
 }
 

--- a/PPDefModifierTests/ApplyModTests.cs
+++ b/PPDefModifierTests/ApplyModTests.cs
@@ -401,10 +401,12 @@ namespace PPDefModifierTests
             TestClass obj = new TestClass { intValue = 10, boolValue = false };
             repo.AddDef("a", obj);
             ModFile m = new ModFile("ModletList", repo);
-            ModifierDefinition mod = new ModifierDefinition { guid = "a", modletlist = new List<ModletStep> {
-                new ModletStep { field = "intValue", value = 20 },
-                new ModletStep { field = "boolValue", value = false}
-            }
+            ModifierDefinition mod = new ModifierDefinition {
+                guid = "a",
+                modletlist = new List<ModletStep> {
+                    new ModletStep { field = "intValue", value = 20 },
+                    new ModletStep { field = "boolValue", value = true}
+                }
             };
             m.ApplyModifier(mod);
             Assert.AreEqual(obj.intValue, 20);
@@ -422,12 +424,12 @@ namespace PPDefModifierTests
             {
                 guid = "a",
                 modletlist = new List<ModletStep> {
-                new ModletStep { field = "intValue", value = 20 },
-                new ModletStep { field = null, value = 20 },
-                new ModletStep { field = "NoValue", value = null },
-                new ModletStep { field = null, value = null },
-                new ModletStep { field = "boolValue", value = false}
-            }
+                    new ModletStep { field = "intValue", value = 20 },
+                    new ModletStep { field = null, value = 20 },
+                    new ModletStep { field = "NoValue", value = null },
+                    new ModletStep { field = null, value = null },
+                    new ModletStep { field = "boolValue", value = true}
+                }
             };
             m.ApplyModifier(mod);
             Assert.AreEqual(obj.intValue, 20);

--- a/PPDefModifierTests/ValidateModTests.cs
+++ b/PPDefModifierTests/ValidateModTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PPDefModifier;
+using System.Collections.Generic;
 
 namespace PPDefModifierTests
 {
@@ -20,6 +21,15 @@ namespace PPDefModifierTests
         {
             ModFile m = new ModFile("BothGuidAndClass", null);
             ModifierDefinition def = new ModifierDefinition { guid = "a", cls = "b", comment = null, value = 0, field = null };
+            Assert.ThrowsException<ModException>(() => m.ValidateModifier(def));
+        }
+
+
+        [TestMethod]
+        public void BothFieldAndModletlist()
+        {
+            ModFile m = new ModFile("BothFieldAndModletlist", null);
+            ModifierDefinition def = new ModifierDefinition { guid = null, cls = "c", comment = null, value = 0, field = "foo", modletlist = new List<ModletStep>() };
             Assert.ThrowsException<ModException>(() => m.ValidateModifier(def));
         }
 


### PR DESCRIPTION
I tweaked the code so that any given patch can apply a list of patches to multiple fields under the same guid/class. Here's an example:

```json
[
    {
        "guid": "b0011318-4762-27d1-3ada-e10fa2d4ab34",
        "modletlist": [
            {
                "field": "SoldiersCapacity",
                "value": 12
            },
            {
                "field": "ItemsCapacity",
                "value": 36,
            },
        ],
        "comment": "LivingQuarters"
    },
    {
        "guid": "df986c6a-fca0-2644-48a5-7860606f3e35",
        "field": "PowerCost",
        "value": 0,
        "comment": "LivingQuarters"
    }
]
```
This way if a lot of fields are being modified for one class, you don't have to have a whole new patch every single time. It gracefully handles any parts of the modletlist that are missing a field or value (or both) and calls the default ApplyModifier() in order to apply the patch.